### PR TITLE
Pagescroll bug fix

### DIFF
--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -479,9 +479,9 @@ angular.module('hl.sticky', [])
 
 						var newWidth = window.innerWidth;
 
-						if (width != newWidth) {
+						if (windowWidth != newWidth) {
 							throttle(resize, $stickyElement.defaults.checkDelay, {leading: false})(arguments);
-							width = newWidth;
+							windowWidth = newWidth;
 						}
 					};
 					windowEl.on('resize', throttledResize);

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -460,6 +460,7 @@ angular.module('hl.sticky', [])
 			$get: function($rootScope, $window, $document, $log, DefaultStickyStackName, hlStickyElement, hlStickyStack, throttle) {
 
 				var windowEl = angular.element($window);
+				var windowWidth = window.innerWidth;
 
 				var unbindViewContentLoaded;
 				var unbindIncludeContentLoaded;
@@ -474,7 +475,15 @@ angular.module('hl.sticky', [])
 					}
 
 					// bind events
-					throttledResize = throttle(resize, $stickyElement.defaults.checkDelay, {leading: false});
+					throttledResize = function(event) {
+
+						var newWidth = window.innerWidth;
+
+						if (width != newWidth) {
+							throttle(resize, $stickyElement.defaults.checkDelay, {leading: false})(arguments);
+							width = newWidth;
+						}
+					};
 					windowEl.on('resize', throttledResize);
 					windowEl.on('scroll', drawEvent);
 


### PR DESCRIPTION
When using angular sticky directive in project, found the bug with page scrolling at new element on page adding. It was because throttledResize function triggered even if window not actually resized. This pull request fixes that bug with comparing width before and after resize event.