### PR TITLE
#39 - make zIndex configurable

### DIFF
--- a/dist/angular-sticky.js
+++ b/dist/angular-sticky.js
@@ -8,10 +8,6 @@
 'use strict';
 
 angular.module('hl.sticky', [])
-	.constant('DefaultStickyStackName', 'default-stack')
-
-	// 1039 should be above all Bootstrap's z-indexes (but just before the modals)
-	.constant('DefaultStickyStackZIndex', 1039)
 
 	.factory('mediaQuery', function () {
 		return {
@@ -39,7 +35,7 @@ angular.module('hl.sticky', [])
 			}
 
 			// should be above all Bootstrap's z-indexes (but just before the modals)
-			var stickyZIndex = options.zIndex;
+			var stickyZIndex = 1039;
 			var stack = [];
 
 			var $stack = {};
@@ -529,7 +525,6 @@ angular.module('hl.sticky', [])
 					options = angular.extend({}, $stickyElement.elementsDefaults, options);
 
 					var collectionName = options.name || DefaultStickyStackName;
-					var zIndex = parseInt(options.zIndex, 10);
 
 					// use existing element collection
 					if ($stickyElement.collections[collectionName]) {
@@ -537,8 +532,7 @@ angular.module('hl.sticky', [])
 					}
 
 					var stickyStackFactory = hlStickyStack({
-						name: collectionName,
-						zIndex: zIndex
+						name: collectionName
 					});
 
 					var trackedElements = [];
@@ -615,7 +609,7 @@ angular.module('hl.sticky', [])
 		return $stickyElement;
 	})
 
-	.directive('hlSticky', ["$log", "$window", "$document", "DefaultStickyStackZIndex", "hlStickyElementCollection", function($log, $window, $document, DefaultStickyStackZIndex, hlStickyElementCollection) {
+	.directive('hlSticky', ["$log", "$window", "$document", "hlStickyElementCollection", function($log, $window, $document, hlStickyElementCollection) {
 		return {
 			restrict: 'A',
 			scope: {
@@ -634,8 +628,7 @@ angular.module('hl.sticky', [])
 
 				var stickyElementCollection = hlStickyElementCollection({
 					name: $scope.collection,
-					parent: $scope.collectionParent,
-					zIndex: $attrs.zIndex || DefaultStickyStackZIndex
+					parent: $scope.collectionParent
 				});
 				var options = {
 					id: $attrs.hlSticky,

--- a/dist/angular-sticky.js
+++ b/dist/angular-sticky.js
@@ -8,6 +8,10 @@
 'use strict';
 
 angular.module('hl.sticky', [])
+	.constant('DefaultStickyStackName', 'default-stack')
+
+	// 1039 should be above all Bootstrap's z-indexes (but just before the modals)
+	.constant('DefaultStickyStackZIndex', 1039)
 
 	.factory('mediaQuery', function () {
 		return {
@@ -35,7 +39,7 @@ angular.module('hl.sticky', [])
 			}
 
 			// should be above all Bootstrap's z-indexes (but just before the modals)
-			var stickyZIndex = 1039;
+			var stickyZIndex = options.zIndex;
 			var stack = [];
 
 			var $stack = {};
@@ -525,6 +529,7 @@ angular.module('hl.sticky', [])
 					options = angular.extend({}, $stickyElement.elementsDefaults, options);
 
 					var collectionName = options.name || DefaultStickyStackName;
+					var zIndex = parseInt(options.zIndex, 10);
 
 					// use existing element collection
 					if ($stickyElement.collections[collectionName]) {
@@ -532,7 +537,8 @@ angular.module('hl.sticky', [])
 					}
 
 					var stickyStackFactory = hlStickyStack({
-						name: collectionName
+						name: collectionName,
+						zIndex: zIndex
 					});
 
 					var trackedElements = [];
@@ -609,7 +615,7 @@ angular.module('hl.sticky', [])
 		return $stickyElement;
 	})
 
-	.directive('hlSticky', ["$log", "$window", "$document", "hlStickyElementCollection", function($log, $window, $document, hlStickyElementCollection) {
+	.directive('hlSticky', ["$log", "$window", "$document", "DefaultStickyStackZIndex", "hlStickyElementCollection", function($log, $window, $document, DefaultStickyStackZIndex, hlStickyElementCollection) {
 		return {
 			restrict: 'A',
 			scope: {
@@ -628,7 +634,8 @@ angular.module('hl.sticky', [])
 
 				var stickyElementCollection = hlStickyElementCollection({
 					name: $scope.collection,
-					parent: $scope.collectionParent
+					parent: $scope.collectionParent,
+					zIndex: $attrs.zIndex || DefaultStickyStackZIndex
 				});
 				var options = {
 					id: $attrs.hlSticky,

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -1,6 +1,10 @@
 'use strict';
 
 angular.module('hl.sticky', [])
+	.constant('DefaultStickyStackName', 'default-stack')
+
+	// 1039 should be above all Bootstrap's z-indexes (but just before the modals)
+	.constant('DefaultStickyStackZIndex', 1039)
 
 	.factory('mediaQuery', function () {
 		return {
@@ -10,7 +14,7 @@ angular.module('hl.sticky', [])
 		};
 	})
 
-	.factory('hlStickyStack', function ($document, DefaultStickyStackName) {
+	.factory('hlStickyStack', function ($document, DefaultStickyStackName, DefaultStickyStackZIndex) {
 
 		var documentEl = $document[0].documentElement;
 
@@ -27,8 +31,7 @@ angular.module('hl.sticky', [])
 				return stacks[stackName];
 			}
 
-			// should be above all Bootstrap's z-indexes (but just before the modals)
-			var stickyZIndex = 1039;
+			var stickyZIndex = options.zIndex || DefaultStickyStackZIndex;
 			var stack = [];
 
 			var $stack = {};
@@ -443,8 +446,6 @@ angular.module('hl.sticky', [])
 		};
 	})
 
-	.constant('DefaultStickyStackName', 'default-stack')
-
 	.provider('hlStickyElementCollection', function() {
 
 		var $$count = 0;
@@ -518,6 +519,7 @@ angular.module('hl.sticky', [])
 					options = angular.extend({}, $stickyElement.elementsDefaults, options);
 
 					var collectionName = options.name || DefaultStickyStackName;
+					var zIndex = parseInt(options.zIndex, 10);
 
 					// use existing element collection
 					if ($stickyElement.collections[collectionName]) {
@@ -525,7 +527,8 @@ angular.module('hl.sticky', [])
 					}
 
 					var stickyStackFactory = hlStickyStack({
-						name: collectionName
+						name: collectionName,
+						zIndex: zIndex
 					});
 
 					var trackedElements = [];
@@ -602,7 +605,7 @@ angular.module('hl.sticky', [])
 		return $stickyElement;
 	})
 
-	.directive('hlSticky', function($log, $window, $document, hlStickyElementCollection) {
+	.directive('hlSticky', function($log, $window, $document, hlStickyElementCollection, DefaultStickyStackZIndex) {
 		return {
 			restrict: 'A',
 			scope: {
@@ -621,7 +624,8 @@ angular.module('hl.sticky', [])
 
 				var stickyElementCollection = hlStickyElementCollection({
 					name: $scope.collection,
-					parent: $scope.collectionParent
+					parent: $scope.collectionParent,
+					zIndex: $attrs.zIndex || DefaultStickyStackZIndex
 				});
 				var options = {
 					id: $attrs.hlSticky,


### PR DESCRIPTION
Connected to #39  

I'm sure there is a better way to do this, but here's a quick fix to allow a `z-index` attribute on the directive.

e.g.
```html
<div class="dashboard-edit-buttons"
     hl-sticky
     z-index="997"
     use-placeholder="false"
     collection="sticky-content-edit-bar"
     offset-top="{{ view.navOffset }}"
     container="mobile-nav-content-wrapper">
```
  