### PR TITLE
Updated sticky

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,12 +37,13 @@ module.exports = function(grunt) {
 			},
 			dev: {
 				background: true,
-				singleRun: false
+				singleRun: false,
+				preprocessors: false,
 			}
 		},
 		connect: {
 			options: {
-				port: 9000,
+				port: 9001, //9000 is very commonly used for other things
 				// Change this to '0.0.0.0' to access the server from outside.
 				hostname: 'localhost',
 				livereload: 35729

--- a/bower.json
+++ b/bower.json
@@ -24,13 +24,13 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "^1.4.0"
+    "angular": "~1.4.0"
   },
   "devDependencies": {
     "underscore": "~1.8.3",
     "jquery": "~2.0.3",
     "bootstrap": "~3.3.6",
-    "angular-mocks": "^1.4.0",
+    "angular-mocks": "~1.4.4",
     "angular-bootstrap": "~1.1.2",
     "angular-ui-router": "~0.2.18",
     "google-code-prettify": "1.0.1",

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,7 @@
 	<title>Angular Sticky</title>
 
 	<!-- build:js(.) scripts/vendor.js -->
+	<script type="text/javascript" src="bower_components/jquery/jquery.js"></script>
 	<script type="text/javascript" src="bower_components/angular/angular.js"></script>
 	<script type="text/javascript" src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
 	<script type="text/javascript" src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>

--- a/demo/less/demos/sticky-stack-bottom/scaffolding.less
+++ b/demo/less/demos/sticky-stack-bottom/scaffolding.less
@@ -1,6 +1,9 @@
 .demo-sticky-stack-bottom {
 	.hl-sticky {
-		.sticky-element-default();
+		.sticky-element-default(60px);
+		&.element-1.sticky-after {
+			background: #666666;
+		}
 	}
 
 	.divider-sticky-elements {

--- a/demo/less/demos/sticky-stack/scaffolding.less
+++ b/demo/less/demos/sticky-stack/scaffolding.less
@@ -1,6 +1,9 @@
 .demo-sticky-stack {
 	.hl-sticky {
-		.sticky-element-default();
+		.sticky-element-default(60px);
+		&.element-1.sticky-before {
+			background: #666666;
+		}
 	}
 
 	.divider {

--- a/demo/less/mixins/sticky-elements.less
+++ b/demo/less/mixins/sticky-elements.less
@@ -16,8 +16,8 @@
 	.box-shadow(0 10px 20px 0px fade(@color, 40%));
 }
 
-.sticky-element-default() {
-	.sticky-element();
+.sticky-element-default(@minHeight: @sticky-element-min-height) {
+	.sticky-element(@minHeight);
 	.sticky-element-shadow();
 	background-color: @gray-dark;
 }

--- a/demo/views/api/directives/hl-sticky.html
+++ b/demo/views/api/directives/hl-sticky.html
@@ -21,7 +21,7 @@
 	     container="id-of-container"
 	     collection="name-of-collection"
 	     collectionParent="name-of-collection"
-	     event="stickyEvent(event)"
+	     event="stickyEvent"
 	     enable="shouldBeSticky"
 	     always-sticky="shouldAlwaysBeSticky">
 		I'll become sticky
@@ -73,7 +73,7 @@
 	<li>
 		<code>event()</code><br>
 		<pre class="code" apply-content highlight-lang="html">
-			<div hl-sticky event="stickyEvent(event)"></div>
+			<div hl-sticky event="event"></div>
 		</pre>
 		More documentation about the parameters can be found here <code><a ui-sref="root.api.service({name: 'hl-sticky-element'})">hlStickyElement</a></code> at <code>event</code>
 	</li>

--- a/demo/views/demos/events.html
+++ b/demo/views/demos/events.html
@@ -72,7 +72,7 @@
 						I'm just here to give the bottom anchored sticky element some room
 					</div>
 
-					<div hl-sticky event="directive.stickyEvent(event)" anchor="bottom">
+					<div hl-sticky event="directive.stickyEvent" anchor="bottom">
 						I'm initialised using the <code>hl-sticky</code> directive. Scroll the page so you can see when something happens.
 
 						<ul class="list-events">

--- a/demo/views/demos/simple-bottom.html
+++ b/demo/views/demos/simple-bottom.html
@@ -25,7 +25,7 @@
 					Scroll down to see the sticky element in action
 				</div>
 				<div save-content="html">
-					<div hl-sticky anchor="bottom" class="simple">
+					<div hl-sticky options="{ anchor: 'bottom' }" class="simple">
 						<span class="not-sticky">Scroll to make me sticky</span>
 						<span class="sticks">Look, I'm sticky!</span>
 					</div>

--- a/demo/views/demos/sticky-stack-bottom.html
+++ b/demo/views/demos/sticky-stack-bottom.html
@@ -42,23 +42,41 @@
 
 		$scope.elements = [
 			{
-				description: 'I\'ll be leading the pack'
+				description: 'I\'ll be leading the pack',
+				options: {
+					anchor: "bottom",
+					container: "container-stack-bottom",
+				}
 			},
 			{
-				description: 'I\'ll append myself to "Element 1"'
+				description: 'I\'ll append myself to "Element 1"',
+				options: {
+					anchor: "bottom",
+					container: "container-stack-bottom",
+					offsetBottom: 30,
+				}
 			},
 			{
-				description: 'Do I still need to explain?'
+				description: 'Do I still need to explain?',
+				options: {
+					anchor: "bottom",
+					container: "container-stack-bottom",
+				}
 			},
 			{
-				description: 'I\'m the last item in the sticky stack'
+				description: 'I\'m the last item in the sticky stack',
+				options: {
+					anchor: "bottom",
+					container: "container-stack-bottom",
+					offsetBottom: 30,
+				}
 			}
 		];
 	}
 </script>
 
 <div>
-	<div class="container-fluid">
+	<div class="container-fluid" id="container-stack-bottom">
 		<div class="row">
 			<div class="col-lg-12" ng-controller="StackController">
 				<hl-scroll-along>
@@ -68,7 +86,7 @@
 				<div save-content="html">
 					<div class="divider-sticky-elements"></div>
 					<div ng-repeat="element in elements">
-						<div hl-sticky anchor="bottom" class="simple">
+						<div hl-sticky options="element.options" ng-class="'element-'+($index+1)" class="simple">
 							<b>Element {{$index + 1}}</b><br>{{element.description}}
 						</div>
 						<div class="divider">I'm just here to give the sticky elements some space</div>

--- a/demo/views/demos/sticky-stack.html
+++ b/demo/views/demos/sticky-stack.html
@@ -42,16 +42,30 @@
 
 		$scope.elements = [
 			{
-				description: 'I\'ll be leading the pack'
+				description: 'I\'ll be leading the pack',
+				options: {
+					anchor: "top",
+					offsetTop: 30,
+				}
 			},
 			{
-				description: 'I\'ll append myself to "Element 1"'
+				description: 'I\'ll append myself to "Element 1"',
+				options: {
+					anchor: "top",
+				}
 			},
 			{
-				description: 'Do I still need to explain?'
+				description: 'Do I still need to explain?',
+				options: {
+					anchor: "top",
+					offsetTop: 30,
+				}
 			},
 			{
-				description: 'I\'m the last item in the sticky stack'
+				description: 'I\'m the last item in the sticky stack',
+				options: {
+					anchor: "top",
+				}
 			}
 		];
 	}
@@ -67,7 +81,7 @@
 				</hl-scroll-along>
 				<div save-content="html">
 					<div ng-repeat="element in elements">
-						<div hl-sticky class="simple">
+						<div hl-sticky options="element.options" ng-class="'element-'+($index+1)" class="simple">
 							<b>Element {{$index + 1}}</b><br>{{element.description}}
 						</div>
 						<div class="divider">I'm just here to give the sticky elements some space</div>

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -10,7 +10,7 @@ angular.module('hl.sticky', [])
 		};
 	})
 
-	.factory('hlStickyStack', function ($document, DefaultStickyStackOptions) {
+	.factory('hlStickyStack', function ($document, StickyStackDefaults) {
 
 		var documentEl = $document[0].documentElement;
 
@@ -20,7 +20,7 @@ angular.module('hl.sticky', [])
 
 			options = options || {};
 
-			var stackName = options.name || DefaultStickyStackOptions.defaultStack;
+			var stackName = options.name || StickyStackDefaults.defaultStack;
 
 			// use existing sticky stack
 			if (stacks[stackName]) {
@@ -28,7 +28,7 @@ angular.module('hl.sticky', [])
 			}
 
 			// should be above all Bootstrap's z-indexes (but just before the modals)
-			var stickyZIndex = options.zIndex || DefaultStickyStackOptions.zIndex;
+			var stickyZIndex = options.zIndex || StickyStackDefaults.zIndex;
 			var stack = [];
 
 			var $stack = {};
@@ -139,7 +139,7 @@ angular.module('hl.sticky', [])
 		return stickyStack;
 	})
 
-	.factory('hlStickyElement', function($document, $log, hlStickyStack, throttle, mediaQuery, DefaultStickyStackOptions) {
+	.factory('hlStickyElement', function($document, $log, hlStickyStack, throttle, mediaQuery, StickyStackDefaults) {
 		return function(element, options) {
 			options = options || {};
 
@@ -158,7 +158,7 @@ angular.module('hl.sticky', [])
 			if (!angular.isFunction(options.event)) {
 				delete options.event;
 			}
-			angular.forEach(DefaultStickyStackOptions, function(value, key) {
+			angular.forEach(StickyStackDefaults, function(value, key) {
 				if (angular.isUndefined(options[key]) || options[key] === "") {
 					options[key] = value;
 				} else if (options[key] && !isNaN(options[key])) {
@@ -188,6 +188,7 @@ angular.module('hl.sticky', [])
 			var initialCSS = {
 				style: element.attr('style') || ''
 			};
+			element.addClass('sticky-'+anchor);
 
 			// Methods
 			//
@@ -492,7 +493,7 @@ angular.module('hl.sticky', [])
 		};
 	})
 
-	.constant('DefaultStickyStackOptions', {
+	.constant('StickyStackDefaults', {
 		id: null,
 		enable: true,
 		mediaQuery: false,
@@ -524,7 +525,7 @@ angular.module('hl.sticky', [])
 			elementsDefaults: {
 
 			},
-			$get: function($rootScope, $window, $document, $log, DefaultStickyStackOptions, hlStickyElement, hlStickyStack, throttle) {
+			$get: function($rootScope, $window, $document, $log, StickyStackDefaults, hlStickyElement, hlStickyStack, throttle) {
 
 				var windowEl = angular.element($window);
 
@@ -586,7 +587,7 @@ angular.module('hl.sticky', [])
 					}
 					options = angular.extend({}, $stickyElement.elementsDefaults, options);
 
-					var collectionName = options.name || DefaultStickyStackOptions.defaultStack;
+					var collectionName = options.name || StickyStackDefaults.defaultStack;
 
 					// use existing element collection
 					if ($stickyElement.collections[collectionName]) {

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -381,7 +381,7 @@ angular.module('hl.sticky', [])
 					var hasScrollDistance = !(scrolledDistance === null || scrolledDistance === undefined);
 					var containerRect = container.getBoundingClientRect();
 					var containerBottom = !hasScrollDistance ? containerRect.top - window.innerHeight + elementHeight() : (_getTopOffset(container) + containerRect.height) - scrolledDistance;
-					return Math.max(0, containerBottom - (offsetTop + _stackOffset(anchor)));
+					return Math.max(0, (containerBottom + offsetTop + offsetBottom) - (_stackOffset(anchor)));
 				}
 				return 0;
 			}
@@ -393,7 +393,7 @@ angular.module('hl.sticky', [])
 					var hasScrollDistance = !(scrolledDistance === null || scrolledDistance === undefined);
 					var containerRect = container.getBoundingClientRect();
 					var containerBottom = !hasScrollDistance ? containerRect.bottom : (_getTopOffset(container) + containerRect.height) - scrolledDistance;
-					return Math.max(0, (offsetTop + _stackOffset(anchor) + elementHeight()) - containerBottom);
+					return Math.max(0, (offsetTop + _stackOffset(anchor) + elementHeight() + offsetBottom) - containerBottom);
 				}
 				return 0;
 			}

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -519,7 +519,7 @@ angular.module('hl.sticky', [])
 		var $stickyElement = {
 			collections: {},
 			defaults: {
-				checkDelay: 250
+				checkDelay: 20
 			},
 			elementsDefaults: {
 
@@ -535,18 +535,20 @@ angular.module('hl.sticky', [])
 				function init() {
 					$$count++;
 
+					resize();
 					// make sure we can initialize it only once
 					if ($$count > 1) {
 						return;
 					}
 
 					// bind events
-					throttledResize = throttle(resize, $stickyElement.defaults.checkDelay, {leading: false});
+					throttledResize = throttle(resize, $stickyElement.defaults.checkDelay);
 					windowEl.on('resize', throttledResize);
 					windowEl.on('scroll', drawEvent);
 
 					unbindViewContentLoaded = $rootScope.$on('$viewContentLoaded', throttledResize);
 					unbindIncludeContentLoaded = $rootScope.$on('$includeContentLoaded', throttledResize);
+
 					throttledResize();
 				}
 
@@ -760,17 +762,10 @@ angular.module('hl.sticky', [])
 				var that = this;
 				var args = arguments;
 
-				if (!timeout) {
-					if (options.leading !== false) {
-						func.apply(that, args);
-					}
-					timeout = $timeout(function later() {
-						timeout = null;
-						if (options.trailing !== false) {
-							func.apply(that, args);
-						}
-					}, wait, false);
-				}
+				$timeout.cancel(timeout);
+				timeout = $timeout(function later() {
+					func.apply(that, args);
+				}, wait, false);
 			};
 		};
 	});

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -155,11 +155,11 @@ angular.module('hl.sticky', [])
 			var documentEl = $document[0].documentElement;
 
 
-			if (!angular.isFunction(options.stickyEvent)) {
-				delete options.stickyEvent;
+			if (!angular.isFunction(options.event)) {
+				delete options.event;
 			}
 			angular.forEach(DefaultStickyStackOptions, function(value, key) {
-				if (angular.isUndefined(options[key])) {
+				if (angular.isUndefined(options[key]) || options[key] === "") {
 					options[key] = value;
 				} else if (options[key] && !isNaN(options[key])) {
 					options[key] *= 1;
@@ -175,7 +175,7 @@ angular.module('hl.sticky', [])
 			var offsetBottom = options.offsetBottom;
 			var anchor = options.anchor.toLowerCase().trim();
 
-			var event = options.stickyEvent;
+			var event = options.event;
 			var stack = options.stack === false ? null : options.stack || hlStickyStack({zIndex:options.zIndex});
 
 			var container = null;
@@ -468,7 +468,7 @@ angular.module('hl.sticky', [])
 		offsetBottom: 0,
 		anchor: 'top',
 		container: null,
-		stickyEvent: angular.noop,
+		event: angular.noop,
 		stack: null,
 		defaultStack: 'default-stack',
 		collection: null,
@@ -648,7 +648,7 @@ angular.module('hl.sticky', [])
 				usePlaceholder: '@',
 				offsetTop: '@',
 				offsetBottom: '@',
-				stickyEvent: '&',
+				event: '&',
 				zIndex: '@',
 				enable: '=',
 				alwaysSticky: '=',
@@ -658,30 +658,27 @@ angular.module('hl.sticky', [])
 				$element.addClass('hl-sticky');
 				var options;
 
-				var defaultEvent = function(event) {
-					$scope.event({
-						event: event
-					})
-				};
-
 				if (!$scope.options) {
 					options = {
 						id: $attrs.hlSticky,
-						stickyEvent: defaultEvent
+						event: function() {
+							var eventHandler = $scope.event();
+							if (angular.isFunction(eventHandler)) {
+								eventHandler.apply(null, arguments);
+							}
+						}
 					};
 					angular.forEach($scope, function(value, key) {
+						if (key === "event") return;
 						if (key[0] !== '$' && angular.isDefined(value)) {
 							options[key] = $scope[key];
-							if (!isNaN(options[key])) {
+							if (options[key] && !isNaN(options[key])) {
 								options[key] *= 1; //convert to number
 							}
 						}
 					});
 				} else {
 					options = $scope.options;
-					if (!options.stickyEvent) {
-						options.stickyEvent = defaultEvent;
-					}
 				}
 
 				var stickyElementCollection = hlStickyElementCollection({

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -321,7 +321,7 @@ angular.module('hl.sticky', [])
 				element.addClass(stickyClass);
 
 				// create placeholder to avoid jump
-				if (usePlaceholder) {
+				if (options.usePlaceholder) {
 					placeholder = placeholder || angular.element('<div>');
 					placeholder.css('height', elementHeight() + 'px');
 					element.after(placeholder);
@@ -683,14 +683,14 @@ angular.module('hl.sticky', [])
 				mediaQuery: '@',
 				collection: '@',
 				collectionParent: '@',
-				usePlaceholder: '@',
 				offsetTop: '@',
 				offsetBottom: '@',
-				event: '&',
 				zIndex: '@',
-				enable: '=',
-				alwaysSticky: '=',
-				options: '='
+				event: '&',
+				usePlaceholder: '=?',
+				enable: '=?',
+				alwaysSticky: '=?',
+				options: '=?'
 			},
 			link: function($scope, $element, $attrs) {
 				$element.addClass('hl-sticky');

--- a/js/angular-sticky.js
+++ b/js/angular-sticky.js
@@ -266,6 +266,8 @@ angular.module('hl.sticky', [])
 					event({event: 'unstick'});
 				}
 
+				setBeforeAfterClass();
+
 				// stick after care
 				if (_isSticking) {
 					// update the top offset at an already sticking element
@@ -277,6 +279,40 @@ angular.module('hl.sticky', [])
 					}
 					element.css('width', elementWidth() + 'px');
 				}
+			}
+
+			function setBeforeAfterClass() {
+				var beforeOrAfter = null
+				element.removeClass(options.beforeStickyClass);
+				element.removeClass(options.afterStickyClass);
+
+				switch (anchor) {
+					case 'top':
+						if (!_isSticking) {
+							element.addClass(options.beforeStickyClass);
+							beforeOrAfter = "before";
+						} else if (containerBoundsBottom() > 0) {
+							element.addClass(options.afterStickyClass);
+							beforeOrAfter = "after";
+						}
+						break;
+					case 'bottom':
+						if (containerBoundsTop() > 0) {
+							element.addClass(options.beforeStickyClass);
+							beforeOrAfter = "before";
+						} else if (!_isSticking) {
+							element.addClass(options.afterStickyClass);
+							beforeOrAfter = "after";
+						}
+						break;
+				}
+				if (beforeOrAfter !== "before") {
+					element.removeClass(options.beforeStickyClass);
+				}
+				if (beforeOrAfter !== "after") {
+					element.removeClass(options.afterStickyClass);
+				}
+
 			}
 
 			function stickElement() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -82,6 +82,9 @@ module.exports = function(config) {
 	if(process.env.TRAVIS){
 		configuration.browsers = ['Chrome_travis_ci'];
 	}
+	if (config.preprocessors === false) {
+		configuration.preprocessors = {};
+	}
 
 	config.set(configuration);
 };

--- a/tests/angular-sticky.spec.js
+++ b/tests/angular-sticky.spec.js
@@ -1048,15 +1048,15 @@ describe('angular-sticky', function() {
 		var $timeout;
 
 		var hlStickyElementCollection;
-		var DefaultStickyStackOptions;
+		var StickyStackDefaults;
 
 		var hlStickyStack;
 
-		beforeEach(inject(function (_$timeout_, _hlStickyElementCollection_, _DefaultStickyStackOptions_, _hlStickyStack_) {
+		beforeEach(inject(function (_$timeout_, _hlStickyElementCollection_, _StickyStackDefaults_, _hlStickyStack_) {
 			$timeout = _$timeout_;
 
 			hlStickyElementCollection = _hlStickyElementCollection_;
-			DefaultStickyStackOptions = _DefaultStickyStackOptions_;
+			StickyStackDefaults = _StickyStackDefaults_;
 
 			hlStickyStack = _hlStickyStack_;
 		}));
@@ -1064,10 +1064,10 @@ describe('angular-sticky', function() {
 		it('creates a new instance of hlStickyElementCollection()', function() {
 			var element = compile(templateStickyElementOffsetSmall);
 
-			expect(hlStickyElementCollectionProvider.collections[DefaultStickyStackOptions.defaultStack]).toBeUndefined();
+			expect(hlStickyElementCollectionProvider.collections[StickyStackDefaults.defaultStack]).toBeUndefined();
 
 			var collection = hlStickyElementCollection();
-			var trackedElements = hlStickyElementCollectionProvider.collections[DefaultStickyStackOptions.defaultStack].trackedElements();
+			var trackedElements = hlStickyElementCollectionProvider.collections[StickyStackDefaults.defaultStack].trackedElements();
 			expect(trackedElements.length).toBe(0);
 
 			collection.addElement(element);
@@ -1087,7 +1087,7 @@ describe('angular-sticky', function() {
 			var element = compile(templateStickyElementOffsetSmall);
 
 			var collection = hlStickyElementCollection();
-			var trackedElements = hlStickyElementCollectionProvider.collections[DefaultStickyStackOptions.defaultStack].trackedElements();
+			var trackedElements = hlStickyElementCollectionProvider.collections[StickyStackDefaults.defaultStack].trackedElements();
 
 			collection.addElement(element);
 			expect(trackedElements.length).toBe(1);
@@ -1115,11 +1115,11 @@ describe('angular-sticky', function() {
 			var stack = hlStickyStack();
 			var collection = hlStickyElementCollection();
 			collection.addElement(element);
-			expect(hlStickyElementCollectionProvider.collections[DefaultStickyStackOptions.defaultStack].trackedElements().length).toBe(1);
+			expect(hlStickyElementCollectionProvider.collections[StickyStackDefaults.defaultStack].trackedElements().length).toBe(1);
 			expect(stack.length()).toBe(1);
 
 			collection.destroy();
-			expect(hlStickyElementCollectionProvider.collections[DefaultStickyStackOptions.defaultStack]).toBeUndefined();
+			expect(hlStickyElementCollectionProvider.collections[StickyStackDefaults.defaultStack]).toBeUndefined();
 			expect(stack.length()).toBe(0);
 		});
 
@@ -1296,6 +1296,8 @@ describe('angular-sticky', function() {
 					var compiled = compileDirective('<div style="height: 20px;"></div><div hl-sticky anchor="top"></div>');
 					var stickyElement = compiled.sticky;
 
+					expect(stickyElement.hasClass('sticky-top')).toBeTruthy();
+
 					// just before it becomes sticky
 					scrollTo(19);
 					scope.$digest();
@@ -1328,6 +1330,8 @@ describe('angular-sticky', function() {
 				it('should stick to the bottom', function() {
 					var compiled = compileDirective(createBottomSticky('<div hl-sticky anchor="bottom">'));
 					var stickyElement = compiled.sticky;
+
+					expect(stickyElement.hasClass('sticky-bottom')).toBeTruthy();
 
 					// just before it becomes sticky
 					scrollToBottom(1);


### PR DESCRIPTION

- Fixes the demo page.
- Refactors the way options are submitted with clear defaults and ability to use a option config object on the directive.
- Fixes handling of offsetBottom when attached top and offsetTop when attached bottom.
- Adds classes attached to object for before it goes sticky, and after it goes sticky
- Adds zIndex option
- Adds tests